### PR TITLE
Make IMicrosoftRestTokenProviderSource non-async

### DIFF
--- a/Solutions/Corvus.Identity.Examples.UsingMicrosoftRest/Corvus/Identity/Examples/UsingMicrosoftRest/UseWebAppManagementAsServiceIdentityWithOldSdk.cs
+++ b/Solutions/Corvus.Identity.Examples.UsingMicrosoftRest/Corvus/Identity/Examples/UsingMicrosoftRest/UseWebAppManagementAsServiceIdentityWithOldSdk.cs
@@ -44,9 +44,8 @@ namespace Corvus.Identity.Examples.UsingMicrosoftRest
         /// </returns>
         public async Task<List<string>> GetWebAppsAsync(string subscriptionId)
         {
-            ITokenProvider tokenProvider = await this.tokenProviderSource.GetTokenProviderAsync(
-                "https://management.azure.com//.default")
-                .ConfigureAwait(false);
+            ITokenProvider tokenProvider = this.tokenProviderSource.GetTokenProvider(
+                "https://management.azure.com//.default");
             var credentials = new TokenCredentials(tokenProvider);
             var client = new WebSiteManagementClient(credentials)
             {

--- a/Solutions/Corvus.Identity.Examples.UsingMicrosoftRest/Corvus/Identity/Examples/UsingMicrosoftRest/UseWebAppManagementWithIdentityFromConfigWithOldSdk.cs
+++ b/Solutions/Corvus.Identity.Examples.UsingMicrosoftRest/Corvus/Identity/Examples/UsingMicrosoftRest/UseWebAppManagementWithIdentityFromConfigWithOldSdk.cs
@@ -53,9 +53,8 @@ namespace Corvus.Identity.Examples.UsingMicrosoftRest
             IMicrosoftRestTokenProviderSource tokenProviderSource = await this.tokenProviderSourceFromConfig
                 .TokenProviderSourceForConfigurationAsync(identity)
                 .ConfigureAwait(false);
-            ITokenProvider tokenProvider = await tokenProviderSource.GetTokenProviderAsync(
-                "https://management.azure.com//.default")
-                .ConfigureAwait(false);
+            ITokenProvider tokenProvider = tokenProviderSource.GetTokenProvider(
+                "https://management.azure.com//.default");
             var credentials = new TokenCredentials(tokenProvider);
             var client = new WebSiteManagementClient(credentials)
             {

--- a/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/IMicrosoftRestTokenProviderSource.cs
+++ b/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/IMicrosoftRestTokenProviderSource.cs
@@ -4,8 +4,6 @@
 
 namespace Corvus.Identity.ClientAuthentication.MicrosoftRest
 {
-    using System.Threading.Tasks;
-
     using Microsoft.Rest;
 
     /// <summary>
@@ -21,8 +19,22 @@ namespace Corvus.Identity.ClientAuthentication.MicrosoftRest
         /// The scopes for which the token is required.
         /// </param>
         /// <returns>
-        /// A task that produces a <see cref="ITokenProvider"/>.
+        /// A <see cref="ITokenProvider"/>.
         /// </returns>
-        ValueTask<ITokenProvider> GetTokenProviderAsync(string[] scopes);
+        /// <remarks>
+        /// <para>
+        /// Whereas the other source types in <c>Corvus.Identity</c> for working directly with
+        /// access tokens (<c>IAccessTokenSource</c>) or <c>Azure.Core</c>-style credentials
+        /// (<c>IAzureTokenCredentialSource</c>) both use async in their equivalents of this
+        /// method, this does not for a couple of reasons. First, <see cref="ITokenProvider"/>
+        /// is inherently asynchronous anyway, so in practice, if failures are going to occur,
+        /// they will happen at the point at which the token provider is first used, and not
+        /// when it is obtained, so making this async would provide a misleading impression of
+        /// when work is actually being done. Secondly, it's common to want to use this from
+        /// process startup code, notably DI initialization, in which async is often not an
+        /// option, so it would be actively unhelpful to make this async.
+        /// </para>
+        /// </remarks>
+        ITokenProvider GetTokenProvider(string[] scopes);
     }
 }

--- a/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/Internal/MicrosoftRestTokenProviderSource.cs
+++ b/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/Internal/MicrosoftRestTokenProviderSource.cs
@@ -4,8 +4,6 @@
 
 namespace Corvus.Identity.ClientAuthentication.MicrosoftRest.Internal
 {
-    using System.Threading.Tasks;
-
     using Microsoft.Rest;
 
     /// <summary>
@@ -28,7 +26,7 @@ namespace Corvus.Identity.ClientAuthentication.MicrosoftRest.Internal
         }
 
         /// <inheritdoc/>
-        public ValueTask<ITokenProvider> GetTokenProviderAsync(string[] scopes)
-            => new (new MicrosoftRestTokenProvider(this.tokenSource, scopes));
+        public ITokenProvider GetTokenProvider(string[] scopes)
+            => new MicrosoftRestTokenProvider(this.tokenSource, scopes);
     }
 }

--- a/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/MicrosoftRestTokenProviderSourceExtensions.cs
+++ b/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/MicrosoftRestTokenProviderSourceExtensions.cs
@@ -4,8 +4,6 @@
 
 namespace Corvus.Identity.ClientAuthentication.MicrosoftRest
 {
-    using System.Threading.Tasks;
-
     using Microsoft.Rest;
 
     /// <summary>
@@ -25,9 +23,9 @@ namespace Corvus.Identity.ClientAuthentication.MicrosoftRest
         /// <returns>
         /// A task that produces a <see cref="ITokenProvider"/>.
         /// </returns>
-        public static ValueTask<ITokenProvider> GetTokenProviderAsync(
+        public static ITokenProvider GetTokenProvider(
             this IMicrosoftRestTokenProviderSource source,
             string scope)
-            => source.GetTokenProviderAsync(new[] { scope });
+            => source.GetTokenProvider(new[] { scope });
     }
 }


### PR DESCRIPTION
Resolves #216

As per #216, the scenario for which `IServiceIdentityMicrosoftRestTokenProviderSource` (which derives from `IMicrosoftRestTokenProviderSource`) was not in fact usable in the scenario it was supposedly intended for. This is because it make `ITokenProvider` instances available with through async method, but the most common case for using it was during DI initialization, in which async is typically not an option.

On inspection, it turned out that there was really no good reason for `IMicrosoftRestTokenProviderSource` to use async—it returns an `ITokenProvider` which is already inherently asynchronous, so there was no benefit to adding another layer of async.