### PR TITLE
Secret caching

### DIFF
--- a/Documentation/adr/0001-secret-caching-layering.md
+++ b/Documentation/adr/0001-secret-caching-layering.md
@@ -6,7 +6,7 @@ Proposed
 
 ## Context
 
-Azure Key Vault is a relatively slow service, and can sometimes take several seconds to return information. Since `Corvus.Identity` often needs to read credentials our of Azure Key Vault, we want to be able to cache information to avoid reading the same secrets repeatedly. We also require an application-controllable cache invalidation mechanism to enable key rotation: the application needs to be able to let `Corvus.Identity` know that the credentials loaded for a particular identity are no longer working, and that if possible, it should try to reload them from source.
+Azure Key Vault is a relatively slow service, and can sometimes take several seconds to return information. Since `Corvus.Identity` often needs to read credentials out of Azure Key Vault, we want to be able to cache information to avoid reading the same secrets repeatedly. We also require an application-controllable cache invalidation mechanism to enable key rotation: the application needs to be able to let `Corvus.Identity` know that the credentials loaded for a particular identity are no longer working, and that if possible, it should try to reload them from source.
 
 ### Option 1: embed caching in the Azure.Core pipeline
 
@@ -44,9 +44,10 @@ This has the following disadvantages
 
 Another implementation option is for the secret cache to be a separate feature used alongside the `SecretClient`. An application can consult the cache and then fall back to the `SecretClient` if necessary.
 
-This has the following advantages:
+This has the following advantages (which include all the advantages of Option 2):
 
 * the cache becomes very simple: it only has to be a cache, and does not need to be anything else (e.g., a proxy for the Key Vault)
+* the client identity affinity can be expressed directly in the API
 * the full power of the Azure Key Vault client SDK remains available because that's what the application uses
 
 This has these disadvantages:

--- a/Documentation/adr/0001-secret-caching-layering.md
+++ b/Documentation/adr/0001-secret-caching-layering.md
@@ -1,0 +1,61 @@
+# `Corvus.Identity` Azure Key Vault secret caching
+
+## Status
+
+Proposed
+
+## Context
+
+Azure Key Vault is a relatively slow service, and can sometimes take several seconds to return information. Since `Corvus.Identity` often needs to read credentials our of Azure Key Vault, we want to be able to cache information to avoid reading the same secrets repeatedly. We also require an application-controllable cache invalidation mechanism to enable key rotation: the application needs to be able to let `Corvus.Identity` know that the credentials loaded for a particular identity are no longer working, and that if possible, it should try to reload them from source.
+
+### Option 1: embed caching in the Azure.Core pipeline
+
+The Azure Client SDK, like all Azure.Core-based libraries, enables customization of communication via its HTTP Pipeline. We can register custom handlers in this pipeline, and it would be possible to implement caching in this way.
+
+This has the following advantages:
+
+* code designed to work with the Key Vault library does not need to be modified: we can just provide it with a suitably-configured `SecretClient`
+* the full functionality of Key Vault is available
+
+It has the following disadvantages:
+
+* if the only thing an application cares about is the actual secret value (just some text), this approach ends up with a great deal of complexity and runtime effort to cache entire responses (which it has to do so that the layers above it in the pipeline continue to work correctly)
+* it's not obvious where to put cache invalidation mechanisms—burying the caching invisibly in the pipeline becomes a disadvantage for applications that care about this
+* because the cache needs to make a copy of the real response, adding cache entries involves asynchronous work (copying the stream) and none of the readily available ways of caching data in .NET cope especially well with that
+
+Also, at the moment there's no good way to enable application code to bring its own `SecretClientOptions`. With this implementation approach we need to set our own options to ensure that our caching components go into the pipeline. We could let the application pass in an options object that we then modify. I'd much prefer to make a clone and modify that, but it's not currently possible with the Azure Client SDK.
+
+### Option 2: cache as layer over Key Vault
+
+Another approach is to write a complete wrapper for the Azure Key Vault client SDK, and to implement the caching in that layer.
+
+This has the following benefits:
+
+* we can cache only what we need (currently just the secret text value), avoiding dealing with async operations during a cache get-or-add operation
+* the implementation is simpler because there's no need to fake things up well enough to fool whatever else may be in the HTTP pipeline
+* the client identity affinity can be expressed directly in the API
+
+This has the following disadvantages
+
+* code needs to be written specially or modified to use this cache
+* this may limit the use of Key Vault—any capabilities not duplicated in the wrapper API will be unavailable
+
+### Option 3: distinct cache mechanism
+
+Another implementation option is for the secret cache to be a separate feature used alongside the `SecretClient`. An application can consult the cache and then fall back to the `SecretClient` if necessary.
+
+This has the following advantages:
+
+* the cache becomes very simple: it only has to be a cache, and does not need to be anything else (e.g., a proxy for the Key Vault)
+* the full power of the Azure Key Vault client SDK remains available because that's what the application uses
+
+This has these disadvantages:
+
+* although the application can use any feature of the Azure Key Vault client SDK, it will only enjoy caching for those bits that the cache explicitly supports; in cases where other features are needed, code has to fall back to the "not using the cache" path
+* code still requires some modification to use the cache (although less than with Option 2)
+
+
+## Decision
+
+We are using option 3: the `ICachingKeyVaultSecretClientFactory` provides a cache that can be consulted, with use of `SecretClient` becoming the fallback. The application then adds newly fetched data to the cache. This interface also provides invalidation support.
+

--- a/Solutions/Corvus.Identity.Abstractions/Corvus/Identity/ClientAuthentication/IAccessTokenSource.cs
+++ b/Solutions/Corvus.Identity.Abstractions/Corvus/Identity/ClientAuthentication/IAccessTokenSource.cs
@@ -41,8 +41,10 @@ namespace Corvus.Identity.ClientAuthentication
         /// Gets a new <see cref="AccessTokenDetail"/> to replace one that seems to have stopped
         /// working.
         /// </summary>
-        /// <param name="failedToken">
-        /// The token that no longer works.
+        /// <param name="requiredTokenCharacteristics">
+        /// Describes the scope (and optionally, other characteristics) required for the token -
+        /// these should match the characteristics that were passed when the token was acquired from
+        /// <see cref="GetAccessTokenAsync(AccessTokenRequest, CancellationToken)"/>.
         /// </param>
         /// <param name="cancellationToken">
         /// May enable the request to be cancelled.
@@ -65,7 +67,7 @@ namespace Corvus.Identity.ClientAuthentication
         /// </para>
         /// </remarks>
         ValueTask<AccessTokenDetail> GetReplacementForFailedAccessTokenAsync(
-            AccessTokenDetail failedToken,
+            AccessTokenRequest requiredTokenCharacteristics,
             CancellationToken cancellationToken = default);
     }
 }

--- a/Solutions/Corvus.Identity.Azure/Corvus.Identity.Azure.csproj
+++ b/Solutions/Corvus.Identity.Azure/Corvus.Identity.Azure.csproj
@@ -23,6 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[6.0.*,)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[6.0.*,)" />
   </ItemGroup>
 

--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/IAzureTokenCredentialSource.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/IAzureTokenCredentialSource.cs
@@ -47,9 +47,6 @@ namespace Corvus.Identity.ClientAuthentication.Azure
         /// Gets a new <see cref="TokenCredential"/> to replace one that seems to have stopped
         /// working.
         /// </summary>
-        /// <param name="failedTokenCredential">
-        /// The credential that no longer works.
-        /// </param>
         /// <param name="cancellationToken">
         /// May enable the request to be cancelled.
         /// </param>
@@ -71,7 +68,6 @@ namespace Corvus.Identity.ClientAuthentication.Azure
         /// </para>
         /// </remarks>
         ValueTask<TokenCredential> GetReplacementForFailedTokenCredentialAsync(
-            TokenCredential failedTokenCredential,
             CancellationToken cancellationToken = default);
     }
 }

--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/AzureTokenCredentialAccessTokenSource.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/AzureTokenCredentialAccessTokenSource.cs
@@ -38,14 +38,9 @@ namespace Corvus.Identity.ClientAuthentication.Azure.Internal
                 TokenCredential tokenCredential = await this.tokenCredentialSource
                     .GetTokenCredentialAsync(cancellationToken)
                     .ConfigureAwait(false);
-                AccessToken result = await tokenCredential.GetTokenAsync(
-                    new TokenRequestContext(
-                        scopes: requiredTokenCharacteristics.Scopes,
-                        claims: requiredTokenCharacteristics.Claims,
-                        tenantId: requiredTokenCharacteristics.AuthorityId),
-                    cancellationToken)
+                return await GetAccessTokenFromTokenCredentialAsync(
+                    requiredTokenCharacteristics, tokenCredential, cancellationToken)
                     .ConfigureAwait(false);
-                return new AccessTokenDetail(result.Token, result.ExpiresOn);
             }
             catch (Exception x)
             {
@@ -54,11 +49,38 @@ namespace Corvus.Identity.ClientAuthentication.Azure.Internal
         }
 
         /// <inheritdoc/>
-        public ValueTask<AccessTokenDetail> GetReplacementForFailedAccessTokenAsync(
-            AccessTokenDetail failedToken,
+        public async ValueTask<AccessTokenDetail> GetReplacementForFailedAccessTokenAsync(
+            AccessTokenRequest requiredTokenCharacteristics,
             CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            try
+            {
+                TokenCredential tokenCredential = await this.tokenCredentialSource
+                    .GetReplacementForFailedTokenCredentialAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                return await GetAccessTokenFromTokenCredentialAsync(
+                    requiredTokenCharacteristics, tokenCredential, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception x)
+            {
+                throw new AccessTokenNotIssuedException(x);
+            }
+        }
+
+        private static async ValueTask<AccessTokenDetail> GetAccessTokenFromTokenCredentialAsync(
+            AccessTokenRequest requiredTokenCharacteristics,
+            TokenCredential tokenCredential,
+            CancellationToken cancellationToken)
+        {
+            AccessToken result = await tokenCredential.GetTokenAsync(
+                new TokenRequestContext(
+                    scopes: requiredTokenCharacteristics.Scopes,
+                    claims: requiredTokenCharacteristics.Claims,
+                    tenantId: requiredTokenCharacteristics.AuthorityId),
+                cancellationToken)
+                .ConfigureAwait(false);
+            return new AccessTokenDetail(result.Token, result.ExpiresOn);
         }
     }
 }

--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/AzureTokenCredentialSourceForSpecificConfiguration.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/AzureTokenCredentialSourceForSpecificConfiguration.cs
@@ -48,11 +48,10 @@ namespace Corvus.Identity.ClientAuthentication.Azure.Internal
 
         /// <inheritdoc/>
         public async ValueTask<TokenCredential> GetReplacementForFailedTokenCredentialAsync(
-            TokenCredential failedTokenCredential,
             CancellationToken cancellationToken)
         {
             IAzureTokenCredentialSource source = await this.EnsureSource(cancellationToken).ConfigureAwait(false);
-            return await source.GetReplacementForFailedTokenCredentialAsync(failedTokenCredential, cancellationToken)
+            return await source.GetReplacementForFailedTokenCredentialAsync(cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/IKeyVaultSecretCache.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/IKeyVaultSecretCache.cs
@@ -19,6 +19,9 @@ namespace Corvus.Identity.ClientAuthentication.Azure.Internal
         /// <param name="secretName">The name of the secret.</param>
         /// <param name="clientIdentity">
         /// The identity that will be used to access the key vault if the secret is not cached.
+        /// This can be null because <see cref="KeyVaultSecretConfiguration.VaultClientIdentity"/>
+        /// is allowed to be null, and that's typically where this comes from. A null value here
+        /// signifies that we want to use the service identity.
         /// </param>
         /// <param name="secret">The secret, or null if the secret is not available.</param>
         /// <returns>
@@ -36,7 +39,8 @@ namespace Corvus.Identity.ClientAuthentication.Azure.Internal
         /// <param name="vaultName">The name of the vault containing the secret.</param>
         /// <param name="secretName">The name of the secret.</param>
         /// <param name="clientIdentity">
-        /// The identity that was used to access the key vault.
+        /// The identity that was used to access the key vault, or null if the service identity was
+        /// used.
         /// </param>
         /// <param name="secret">The secret.</param>
         void AddSecret(

--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/IKeyVaultSecretCache.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/IKeyVaultSecretCache.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="IKeyVaultSecretCache.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Identity.ClientAuthentication.Azure.Internal
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Caches secrets to avoid repeated lookups in Azure Key Vault.
+    /// </summary>
+    internal interface IKeyVaultSecretCache
+    {
+        /// <summary>
+        /// Retrieve a cached secret it one is available for the specified combination of vault
+        /// name, secret name, and client identity.
+        /// </summary>
+        /// <param name="vaultName">The name of the vault containing the secret.</param>
+        /// <param name="secretName">The name of the secret.</param>
+        /// <param name="clientIdentity">
+        /// The identity that will be used to access the key vault if the secret is not cached.
+        /// </param>
+        /// <param name="secret">The secret, or null if the secret is not available.</param>
+        /// <returns>
+        /// True if the cache contains this secret.
+        /// </returns>
+        bool TryGetSecret(
+            string vaultName,
+            string secretName,
+            ClientIdentityConfiguration? clientIdentity,
+            [NotNullWhen(true)] out string? secret);
+
+        /// <summary>
+        /// Adds a secret to the cache.
+        /// </summary>
+        /// <param name="vaultName">The name of the vault containing the secret.</param>
+        /// <param name="secretName">The name of the secret.</param>
+        /// <param name="clientIdentity">
+        /// The identity that was used to access the key vault.
+        /// </param>
+        /// <param name="secret">The secret.</param>
+        void AddSecret(
+            string vaultName,
+            string secretName,
+            ClientIdentityConfiguration? clientIdentity,
+            string secret);
+
+        /// <summary>
+        /// Removes a secret from the cache, if it is present.
+        /// </summary>
+        /// <param name="vaultName">The name of the vault containing the secret.</param>
+        /// <param name="secretName">The name of the secret.</param>
+        /// <param name="clientIdentity">
+        /// The identity that was used to access the key vault.
+        /// </param>
+        void InvalidateSecret(
+            string vaultName,
+            string secretName,
+            ClientIdentityConfiguration? clientIdentity);
+    }
+}

--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/KeyVaultSecretCache.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/KeyVaultSecretCache.cs
@@ -1,0 +1,64 @@
+﻿// <copyright file="KeyVaultSecretCache.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Identity.ClientAuthentication.Azure.Internal
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Text.Json;
+
+    using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Extensions.Options;
+
+    /// <summary>
+    /// Caches secrets to avoid repeated lookups in Azure Key Vault.
+    /// </summary>
+    internal class KeyVaultSecretCache : IKeyVaultSecretCache
+    {
+        private static readonly MemoryCacheEntryOptions EntryOptions = new ()
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(20),
+        };
+
+        private readonly MemoryCache cache = new (
+            new OptionsWrapper<MemoryCacheOptions>(new MemoryCacheOptions()));
+
+        /// <inheritdoc/>
+        public void AddSecret(string vaultName, string secretName, ClientIdentityConfiguration? clientIdentity, string secret)
+        {
+            string key = GetKey(vaultName, secretName, clientIdentity);
+            this.cache.Set(key, secret, EntryOptions);
+        }
+
+        /// <inheritdoc/>
+        public void InvalidateSecret(string vaultName, string secretName, ClientIdentityConfiguration? clientIdentity)
+        {
+            string key = GetKey(vaultName, secretName, clientIdentity);
+            this.cache.Remove(key);
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetSecret(
+            string vaultName,
+            string secretName,
+            ClientIdentityConfiguration? clientIdentity,
+            [NotNullWhen(true)] out string? secret)
+        {
+            string key = GetKey(vaultName, secretName, clientIdentity);
+            return this.cache.TryGetValue(key, out secret);
+        }
+
+        private static string GetKey (
+            string vaultName,
+            string secretName,
+            ClientIdentityConfiguration? clientIdentity)
+        {
+            // TODO: this is a placeholder. It is not efficient.
+            string clientIdText = clientIdentity is null
+                ? "service"
+                : JsonSerializer.Serialize(clientIdentity);
+            return $"V:{vaultName},S:{secretName},I{clientIdText}";
+        }
+    }
+}

--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/ServiceIdentityAzureTokenCredentialSource.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/ServiceIdentityAzureTokenCredentialSource.cs
@@ -39,8 +39,7 @@ namespace Corvus.Identity.ClientAuthentication.Azure.Internal
 
         /// <inheritdoc/>
         public ValueTask<TokenCredential> GetReplacementForFailedTokenCredentialAsync(
-            TokenCredential failedTokenCredential,
             CancellationToken cancellationToken)
-            => this.underlyingSource.GetReplacementForFailedTokenCredentialAsync(failedTokenCredential, cancellationToken);
+            => this.underlyingSource.GetReplacementForFailedTokenCredentialAsync(cancellationToken);
     }
 }

--- a/Solutions/Corvus.Identity.Azure/Microsoft/Extensions/DependencyInjection/AzureIdentityServiceCollectionExtensions.cs
+++ b/Solutions/Corvus.Identity.Azure/Microsoft/Extensions/DependencyInjection/AzureIdentityServiceCollectionExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             TokenCredential tokenCredential)
         {
-            AzureTokenCredentialSource source = new (tokenCredential);
+            AzureTokenCredentialSource source = new (tokenCredential, null);
             return services
                 .AddSingleton<IServiceIdentityAzureTokenCredentialSource>(new ServiceIdentityAzureTokenCredentialSource(source))
                 .AddSingleton<IServiceIdentityAccessTokenSource, ServiceIdentityAccessTokenSource>();
@@ -123,6 +123,7 @@ namespace Microsoft.Extensions.DependencyInjection
             return services
                 .AddSingleton<IAzureTokenCredentialSourceFromDynamicConfiguration, AzureTokenCredentialSourceFromConfiguration>()
                 .AddSingleton<IAccessTokenSourceFromDynamicConfiguration, AccessTokenSourceFromDynamicConfiguration>()
+                .AddSingleton<IKeyVaultSecretCache, KeyVaultSecretCache>()
                 .AddSingleton<IKeyVaultSecretClientFactory, KeyVaultSecretClientFactory>();
         }
     }

--- a/Solutions/Corvus.Identity.Examples.AzureFunctions/packages.lock.json
+++ b/Solutions/Corvus.Identity.Examples.AzureFunctions/packages.lock.json
@@ -401,6 +401,26 @@
           "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
         }
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "bcz5sSFJbganH0+YrfvIjJDIcKNW7TL07C4d1eTmXy/wOt52iz4LVogJb6pazs7W0+74j0YpXFErvp++Aq5Bsw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Ve3BlCzhAlVp5IgO3+8dacAhZk1A0GlIlFNkAcfR2TfAibLKWIt5DhVJZfu4YtW+XZ89OjYf/agMcgjDtPxdGA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
+        }
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "2.1.0",
@@ -1672,6 +1692,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Corvus.Identity.Abstractions": "1.0.0",
+          "Microsoft.Extensions.Caching.Memory": "6.0.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
         }
       },

--- a/Solutions/Corvus.Identity.Specs/Corvus.Identity.Specs.csproj
+++ b/Solutions/Corvus.Identity.Specs/Corvus.Identity.Specs.csproj
@@ -11,7 +11,7 @@
          public for technical reasaons, but they are not meant for public consumption, so XML doc comments are only
          appropriate if they aid understanding within the project.
     -->
-    <NoWarn>SA0001;SA1204;SA1600;SA1602;CS1591</NoWarn>
+    <NoWarn>SA0001;SA1204;SA1201;SA1600;SA1602;CS1591</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -48,9 +48,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[6.0.*,)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[6.0.*,)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[6.0.*,)" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.7" />
   </ItemGroup>
   <ItemGroup>

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/AzureTokenCredentialAccessTokenSource.feature
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/AzureTokenCredentialAccessTokenSource.feature
@@ -71,3 +71,20 @@ Scenario: Token acquisition fails with AuthenticationFailedException
     And the underlying TokenCredential throws a 'AuthenticationFailedException'
     Then IAccessTokenSource.GetAccessTokenAsync should have thrown an AccessTokenNotIssuedException
     And the AccessTokenNotIssuedException.InnerException should be the exception thrown by the underlying TokenCredential
+
+# Sometimes applications find that a token that was once working no longer is. In situations where key
+# rotation is in use, this is normal, and applications can tell the token source that they want it to
+# try to reload the credentials behind the source.
+Scenario: Replace token
+    Given the AccessTokenRequest scope is 'https://management.core.windows.net/.default'
+    And the AccessTokenRequest has additional claims of 'claim1 claim2'
+    And IAccessTokenSource.GetAccessTokenAsync is called
+    When IAccessTokenSource.GetReplacementForFailedAccessTokenAsync is called
+    And the underlying TokenCredential returns a successful result
+    Then the IAzureTokenCredentialSource should have been asked to replace the credential
+    And the scope should have been passed on to TokenCredential.GetTokenAsync
+    And the Claims should have been passed on to TokenCredential.GetTokenAsync
+    And the TenantId passed to TokenCredential.GetTokenAsync should be null
+    And the ParentRequestId passed to TokenCredential.GetTokenAsync should be null
+    And the AccessToken returned by IAccessTokenSource.GetAccessTokenAsync should be the same as was returned by TokenCredential.GetTokenAsync
+    And the ExpiresOn returned by IAccessTokenSource.GetAccessTokenAsync should be the same as was returned by TokenCredential.GetTokenAsync

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/AzureTokenCredentialAccessTokenSourceSteps.cs
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/AzureTokenCredentialAccessTokenSourceSteps.cs
@@ -11,8 +11,6 @@
     using global::Azure.Core;
     using global::Azure.Identity;
 
-    using Microsoft.Extensions.DependencyInjection;
-
     using NUnit.Framework;
 
     using TechTalk.SpecFlow;
@@ -35,11 +33,6 @@
 
         public AzureTokenCredentialAccessTokenSourceSteps()
         {
-            ////var services = new ServiceCollection();
-            ////services.AddServiceIdentityAzureTokenCredentialSourceFromAzureCoreTokenCredential(new TestTokenCredential(this));
-            ////ServiceProvider sp = services.BuildServiceProvider();
-            ////this.source = sp.GetRequiredService<IServiceIdentityAccessTokenSource>();
-
             this.source = new AzureTokenCredentialAccessTokenSource(
                 new AzureTokenCredentialSource(
                     new TestTokenCredential(this),

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/AzureTokenCredentialAccessTokenSourceSteps.cs
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/AzureTokenCredentialAccessTokenSourceSteps.cs
@@ -84,7 +84,7 @@
                     "CredentialUnavailableException" => new CredentialUnavailableException("That's not there"),
                     "AuthenticationFailedException" => new AuthenticationFailedException("That didn't work"),
 
-                    _ => new InvalidOperationException($"Bad exceptionType in test: {exceptionType}")
+                    _ => new InvalidOperationException($"Bad exceptionType in test: {exceptionType}"),
                 });
         }
 

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/AzureTokenCredentialAccessTokenSourceSteps.cs
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/AzureTokenCredentialAccessTokenSourceSteps.cs
@@ -1,6 +1,7 @@
 ﻿namespace Corvus.Identity.Azure
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -20,22 +21,29 @@
     public class AzureTokenCredentialAccessTokenSourceSteps
     {
         private readonly TaskCompletionSource<AccessToken> taskForResultFromUnderlyingCredential = new ();
+        private readonly List<TestTokenCredential> replacementCredentials = new ();
         private readonly IAccessTokenSource source;
 #nullable disable annotations
         private string[] scopes;
         private string claims;
         private string authorityId;
         private Task<AccessTokenDetail> accessTokenDetailReturnedTask;
+        private Task<AccessTokenDetail> replacedTokenDetailTask;
 #nullable restore annotations
         private TokenRequestContext requestContextPassedToUnderlyingCredential;
         private AccessToken resultFromUnderlyingCredential;
 
         public AzureTokenCredentialAccessTokenSourceSteps()
         {
-            var services = new ServiceCollection();
-            services.AddServiceIdentityAzureTokenCredentialSourceFromAzureCoreTokenCredential(new TestTokenCredential(this));
-            ServiceProvider sp = services.BuildServiceProvider();
-            this.source = sp.GetRequiredService<IServiceIdentityAccessTokenSource>();
+            ////var services = new ServiceCollection();
+            ////services.AddServiceIdentityAzureTokenCredentialSourceFromAzureCoreTokenCredential(new TestTokenCredential(this));
+            ////ServiceProvider sp = services.BuildServiceProvider();
+            ////this.source = sp.GetRequiredService<IServiceIdentityAccessTokenSource>();
+
+            this.source = new AzureTokenCredentialAccessTokenSource(
+                new AzureTokenCredentialSource(
+                    new TestTokenCredential(this),
+                    _ => this.ReplacementTokenRequested()));
         }
 
         [Given("the AccessTokenRequest scope is '(.*)'")]
@@ -56,10 +64,19 @@
             this.authorityId = authorityId;
         }
 
+        [Given(@"IAccessTokenSource\.GetAccessTokenAsync is called")]
         [When(@"IAccessTokenSource\.GetAccessTokenAsync is called")]
         public void WhenIAccessTokenSource_GetAccessTokenAsyncIsCalled()
         {
             this.accessTokenDetailReturnedTask = this.source.GetAccessTokenAsync(
+                new AccessTokenRequest(this.scopes, this.claims, this.authorityId),
+                CancellationToken.None).AsTask();
+        }
+
+        [When(@"IAccessTokenSource\.GetReplacementForFailedAccessTokenAsync is called")]
+        public void WhenIAccessTokenSource_GetReplacementForFailedAccessTokenAsyncIsCalled()
+        {
+            this.replacedTokenDetailTask = this.source.GetReplacementForFailedAccessTokenAsync(
                 new AccessTokenRequest(this.scopes, this.claims, this.authorityId),
                 CancellationToken.None).AsTask();
         }
@@ -86,6 +103,12 @@
 
                     _ => new InvalidOperationException($"Bad exceptionType in test: {exceptionType}"),
                 });
+        }
+
+        [Then("the IAzureTokenCredentialSource should have been asked to replace the credential")]
+        public void ThenTheIAzureTokenCredentialSourceShouldHaveBeenAskedToReplaceTheCredential()
+        {
+            Assert.AreEqual(1, this.replacementCredentials.Count);
         }
 
         [Then(@"the scope should have been passed on to TokenCredential\.GetTokenAsync")]
@@ -162,6 +185,13 @@
             {
                 Assert.AreSame(this.taskForResultFromUnderlyingCredential.Task.Exception!.InnerException, x.InnerException);
             }
+        }
+
+        private ValueTask<TokenCredential> ReplacementTokenRequested()
+        {
+            TestTokenCredential replacement = new (this);
+            this.replacementCredentials.Add(replacement);
+            return new ValueTask<TokenCredential>(replacement);
         }
 
         private class TestTokenCredential : TokenCredential

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/ClientIdentityConfiguration.feature
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/ClientIdentityConfiguration.feature
@@ -60,11 +60,40 @@ Scenario: Service principle client ID in configuration and secret in key vault v
     And the key vault 'myvault' returns 's3cret!' for the secret named 'MyAzureAdAppClientSecret'
     When a TokenCredential is fetched for this configuration as credential 'TargetCredentials'
     And in this test we identify the token credential passed when creating the key vault 'myvault' as 'MyVault'
-    Then the TokenCredential 'TargetCredentials' should be of type 'ClientSecretCredential'
+    Then the secret cache should have seen these requests
+    | VaultName | SecretName               | Credential |
+    | myvault   | MyAzureAdAppClientSecret | null       |
+    And the TokenCredential 'TargetCredentials' should be of type 'ClientSecretCredential'
 	And the ClientSecretCredential 'TargetCredentials' tenantId should be 'b39db674-9ba1-4343-8d4e-004675b5d7a8'
 	And the ClientSecretCredential 'TargetCredentials' appId should be '831c7dcb-516a-4e6b-9b74-347264c67397'
 	And the ClientSecretCredential 'TargetCredentials' clientSecret should be 's3cret!'
     And the TokenCredential 'MyVault' should be of type 'ManagedIdentityCredential'
+    And the key vault client should have been used 1 times
+
+Scenario: Service principle client ID in configuration and secret in key vault via service identity when secret is in cache
+    Given configuration of
+        """
+        {
+          "ClientIdentity": {
+            "AzureAdAppTenantId": "b39db674-9ba1-4343-8d4e-004675b5d7a8",
+            "AzureAdAppClientId": "831c7dcb-516a-4e6b-9b74-347264c67397",
+            "AzureAdAppClientSecretInKeyVault": {
+              "VaultName": "myvault",
+              "SecretName": "MyAzureAdAppClientSecret" 
+            }
+          }
+        }
+        """
+    And the secret cache returns 's3cret!' for the secret named 'MyAzureAdAppClientSecret' in 'myvault'
+    When a TokenCredential is fetched for this configuration as credential 'TargetCredentials'
+    Then the secret cache should have seen these requests
+    | VaultName | SecretName               | Credential |
+    | myvault   | MyAzureAdAppClientSecret | null       |
+    And the TokenCredential 'TargetCredentials' should be of type 'ClientSecretCredential'
+	And the ClientSecretCredential 'TargetCredentials' tenantId should be 'b39db674-9ba1-4343-8d4e-004675b5d7a8'
+	And the ClientSecretCredential 'TargetCredentials' appId should be '831c7dcb-516a-4e6b-9b74-347264c67397'
+	And the ClientSecretCredential 'TargetCredentials' clientSecret should be 's3cret!'
+    And the key vault client should have been used 0 times
 
 # Using an outline here purely so that we can use symbolic names for the various values.
 Scenario Outline: Service principle client ID in configuration and secret in key vault via different service identity with client ID in config and secret in key vault via service identity
@@ -95,7 +124,11 @@ Scenario Outline: Service principle client ID in configuration and secret in key
     When a TokenCredential is fetched for this configuration as credential 'TargetCredentials'
     And in this test we identify the token credential passed when creating the key vault 'customervault' as 'CustomerCredentials'
     And in this test we identify the token credential passed when creating the key vault 'myvault' as 'OurVaultCredentials'
-    Then the TokenCredential 'TargetCredentials' should be of type 'ClientSecretCredential'
+    Then the secret cache should have seen these requests
+    | VaultName     | SecretName                                               | Credential                                                        |
+    | customervault | CustomerAzureAdAppClientSecret                           | AzureAdAppClientSecretInKeyVault                                  |
+    | myvault       | ClientSecretForAzureAdAppWithWhichWeAccessClientKeyVault | AzureAdAppClientSecretInKeyVault.AzureAdAppClientSecretInKeyVault |
+    And the TokenCredential 'TargetCredentials' should be of type 'ClientSecretCredential'
 	And the ClientSecretCredential 'TargetCredentials' tenantId should be '<targetTenantId>'
 	And the ClientSecretCredential 'TargetCredentials' appId should be '<targetClientId>'
 	And the ClientSecretCredential 'TargetCredentials' clientSecret should be '<targetClientSecret>'
@@ -104,6 +137,89 @@ Scenario Outline: Service principle client ID in configuration and secret in key
 	And the ClientSecretCredential 'CustomerCredentials' appId should be '<customerVaultClientId>'
 	And the ClientSecretCredential 'CustomerCredentials' clientSecret should be '<customerVaultClientSecretInOurVault>'
     And the TokenCredential 'OurVaultCredentials' should be of type 'ManagedIdentityCredential'
+    And the key vault client should have been used 2 times
+
+    Examples:
+        | targetTenantId                       | targetClientId                       | targetClientSecret | customerVaultTenantId                | customerVaultClientId                | customerVaultClientSecretInOurVault |
+        | d0e416b5-1b5d-431e-9448-94a70453889f | 2c5cb5ea-e304-40cf-bdca-81a0d8cf3968 | targetsecret!      | b39db674-9ba1-4343-8d4e-004675b5d7a8 | 831c7dcb-516a-4e6b-9b74-347264c67397 | vaultSpSecret                       |
+
+Scenario Outline: Service principle client ID in configuration and secret in key vault via different service identity with client ID in config and secret in key vault via service identity when inner secret is in cache
+    Given configuration of
+        """
+        {
+          "ClientIdentity": {
+            "AzureAdAppTenantId": "<targetTenantId>",
+            "AzureAdAppClientId": "<targetClientId>",
+            "AzureAdAppClientSecretInKeyVault": {
+              "VaultName": "customervault",
+              "SecretName": "CustomerAzureAdAppClientSecret",
+              "VaultClientIdentity": {
+                "AzureAdAppTenantId": "<customerVaultTenantId>",
+                "AzureAdAppClientId": "<customerVaultClientId>",
+                "AzureAdAppClientSecretInKeyVault": {
+                  "VaultName": "myvault",
+                  "SecretName": "ClientSecretForAzureAdAppWithWhichWeAccessClientKeyVault",
+                  "VaultClientIdentity": { "IdentitySourceType": "Managed" }
+                }
+              }
+            }
+          }
+        }
+        """
+    And the key vault 'customervault' returns '<targetClientSecret>' for the secret named 'CustomerAzureAdAppClientSecret'
+    And the secret cache returns '<customerVaultClientSecretInOurVault>' for the secret named 'ClientSecretForAzureAdAppWithWhichWeAccessClientKeyVault' in 'myvault'
+    When a TokenCredential is fetched for this configuration as credential 'TargetCredentials'
+    And in this test we identify the token credential passed when creating the key vault 'customervault' as 'CustomerCredentials'
+    Then the secret cache should have seen these requests
+    | VaultName     | SecretName                                               | Credential                                                        |
+    | customervault | CustomerAzureAdAppClientSecret                           | AzureAdAppClientSecretInKeyVault                                  |
+    | myvault       | ClientSecretForAzureAdAppWithWhichWeAccessClientKeyVault | AzureAdAppClientSecretInKeyVault.AzureAdAppClientSecretInKeyVault |
+    And the TokenCredential 'TargetCredentials' should be of type 'ClientSecretCredential'
+	And the ClientSecretCredential 'TargetCredentials' tenantId should be '<targetTenantId>'
+	And the ClientSecretCredential 'TargetCredentials' appId should be '<targetClientId>'
+	And the ClientSecretCredential 'TargetCredentials' clientSecret should be '<targetClientSecret>'
+    And the TokenCredential 'CustomerCredentials' should be of type 'ClientSecretCredential'
+	And the ClientSecretCredential 'CustomerCredentials' tenantId should be '<customerVaultTenantId>'
+	And the ClientSecretCredential 'CustomerCredentials' appId should be '<customerVaultClientId>'
+	And the ClientSecretCredential 'CustomerCredentials' clientSecret should be '<customerVaultClientSecretInOurVault>'
+    And the key vault client should have been used 1 times
+
+    Examples:
+        | targetTenantId                       | targetClientId                       | targetClientSecret | customerVaultTenantId                | customerVaultClientId                | customerVaultClientSecretInOurVault |
+        | d0e416b5-1b5d-431e-9448-94a70453889f | 2c5cb5ea-e304-40cf-bdca-81a0d8cf3968 | targetsecret!      | b39db674-9ba1-4343-8d4e-004675b5d7a8 | 831c7dcb-516a-4e6b-9b74-347264c67397 | vaultSpSecret                       |
+
+Scenario Outline: Service principle client ID in configuration and secret in key vault via different service identity with client ID in config and secret in key vault via service identity when outer secret is in cache
+    Given configuration of
+        """
+        {
+          "ClientIdentity": {
+            "AzureAdAppTenantId": "<targetTenantId>",
+            "AzureAdAppClientId": "<targetClientId>",
+            "AzureAdAppClientSecretInKeyVault": {
+              "VaultName": "customervault",
+              "SecretName": "CustomerAzureAdAppClientSecret",
+              "VaultClientIdentity": {
+                "AzureAdAppTenantId": "<customerVaultTenantId>",
+                "AzureAdAppClientId": "<customerVaultClientId>",
+                "AzureAdAppClientSecretInKeyVault": {
+                  "VaultName": "myvault",
+                  "SecretName": "ClientSecretForAzureAdAppWithWhichWeAccessClientKeyVault",
+                  "VaultClientIdentity": { "IdentitySourceType": "Managed" }
+                }
+              }
+            }
+          }
+        }
+        """
+    And the secret cache returns '<targetClientSecret>' for the secret named 'CustomerAzureAdAppClientSecret' in 'customervault'
+    When a TokenCredential is fetched for this configuration as credential 'TargetCredentials'
+    Then the secret cache should have seen these requests
+    | VaultName     | SecretName                                               | Credential                                                        |
+    | customervault | CustomerAzureAdAppClientSecret                           | AzureAdAppClientSecretInKeyVault                                  |
+    And the TokenCredential 'TargetCredentials' should be of type 'ClientSecretCredential'
+	And the ClientSecretCredential 'TargetCredentials' tenantId should be '<targetTenantId>'
+	And the ClientSecretCredential 'TargetCredentials' appId should be '<targetClientId>'
+	And the ClientSecretCredential 'TargetCredentials' clientSecret should be '<targetClientSecret>'
 
     Examples:
         | targetTenantId                       | targetClientId                       | targetClientSecret | customerVaultTenantId                | customerVaultClientId                | customerVaultClientSecretInOurVault |

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/KeyVaultBindings.cs
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/KeyVaultBindings.cs
@@ -16,6 +16,7 @@
 
     using TechTalk.SpecFlow;
     using Moq;
+    using NUnit.Framework;
 
     [Binding]
     public class KeyVaultBindings
@@ -56,10 +57,16 @@
             this.tokenCredentials.SetNamedCredential(credentialName, keyVaultCredentials);
         }
 
+        [Then(@"the key vault client should have been used (\d+) times")]
+        public void ThenTheKeyVaultClientShouldNotHaveBeenUsed(int times)
+        {
+            Assert.AreEqual(times, this.VaultCredentialPairs.Count);
+        }
+
         private class FakeKeyVaultSecretClientFactory : IKeyVaultSecretClientFactory
         {
             private readonly IList<(string KeyVaultName, TokenCredential Credential)> vaultCredentialPairs;
-            private readonly Dictionary<(string vaultName, string secretName), string> secrets = new ();
+            private readonly Dictionary<(string VaultName, string secretName), string> secrets = new ();
 
             public FakeKeyVaultSecretClientFactory(
                 IList<(string KeyVaultName, TokenCredential Credential)> vaultCredentialPairs)

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/ManagedServiceIdentity/ClientAuthentication/ServiceIdentityMicrosoftRestTokenProviderSteps.cs
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/ManagedServiceIdentity/ClientAuthentication/ServiceIdentityMicrosoftRestTokenProviderSteps.cs
@@ -85,7 +85,7 @@ namespace Corvus.Identity.ManagedServiceIdentity.ClientAuthentication
                 AccessTokenRequest requiredTokenCharacteristics,
                 CancellationToken cancellationToken)
             {
-                throw new NotImplementedException();
+                throw new NotSupportedException();
             }
         }
     }

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/ManagedServiceIdentity/ClientAuthentication/ServiceIdentityMicrosoftRestTokenProviderSteps.cs
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/ManagedServiceIdentity/ClientAuthentication/ServiceIdentityMicrosoftRestTokenProviderSteps.cs
@@ -82,7 +82,7 @@ namespace Corvus.Identity.ManagedServiceIdentity.ClientAuthentication
             }
 
             public ValueTask<AccessTokenDetail> GetReplacementForFailedAccessTokenAsync(
-                AccessTokenDetail failedToken,
+                AccessTokenRequest requiredTokenCharacteristics,
                 CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();

--- a/Solutions/Corvus.Identity.Specs/packages.lock.json
+++ b/Solutions/Corvus.Identity.Specs/packages.lock.json
@@ -229,6 +229,26 @@
           "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
         }
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "bcz5sSFJbganH0+YrfvIjJDIcKNW7TL07C4d1eTmXy/wOt52iz4LVogJb6pazs7W0+74j0YpXFErvp++Aq5Bsw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "Ve3BlCzhAlVp5IgO3+8dacAhZk1A0GlIlFNkAcfR2TfAibLKWIt5DhVJZfu4YtW+XZ89OjYf/agMcgjDtPxdGA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
+        }
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -297,6 +317,20 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "ip8jnL1aPiaPeKINCqaTEbvBFDmVx9dXQEBZ2HOBRXPD1eabGNqP/bKlsIcp7U2lGxiXd5xIhoFcmY8nM4Hdiw=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "dzXN0+V1AyjOe2xcJ86Qbo233KHuLEY0njf/P2Kw8SfJU+d45HNS2ctJdnEnrWbM9Ye2eFgaC5Mj9otRMU6IsQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
+        }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
@@ -1586,6 +1620,7 @@
           "Azure.Identity": "1.5.0",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
           "Corvus.Identity.Abstractions": "1.0.0",
+          "Microsoft.Extensions.Caching.Memory": "6.0.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0"
         }
       },


### PR DESCRIPTION
This avoids having to fake out responses from Key Vault by working at a level higher up: this inspects the cache when deciding whether to even talk to Key Vault.