### PR TITLE
Cache invalidation at higher scope

### DIFF
--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/IAccessTokenSourceFromDynamicConfiguration.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/IAccessTokenSourceFromDynamicConfiguration.cs
@@ -32,5 +32,17 @@ namespace Corvus.Identity.ClientAuthentication.Azure
         ValueTask<IAccessTokenSource> AccessTokenSourceForConfigurationAsync(
             ClientIdentityConfiguration configuration,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes any cached tokens for the specified identity. Called when an application has
+        /// reason to believe that credentials are out of date, and may need underlying secrets to
+        /// be reloaded.
+        /// </summary>
+        /// <param name="configuration">
+        /// The <see cref="ClientIdentityConfiguration"/> describing the identity for which cached
+        /// credentials no longer seem to be working..
+        /// </param>
+        void InvalidateFailedAccessToken(
+            ClientIdentityConfiguration configuration);
     }
 }

--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/IAzureTokenCredentialSourceFromDynamicConfiguration.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/IAzureTokenCredentialSourceFromDynamicConfiguration.cs
@@ -27,5 +27,17 @@ namespace Corvus.Identity.ClientAuthentication.Azure
         ValueTask<IAzureTokenCredentialSource> CredentialSourceForConfigurationAsync(
             ClientIdentityConfiguration configuration,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes any cached tokens for the specified identity. Called when an application has
+        /// reason to believe that credentials are out of date, and may need underlying secrets to
+        /// be reloaded.
+        /// </summary>
+        /// <param name="configuration">
+        /// The <see cref="ClientIdentityConfiguration"/> describing the identity for which cached
+        /// credentials no longer seem to be working..
+        /// </param>
+        void InvalidateFailedAccessToken(
+            ClientIdentityConfiguration configuration);
     }
 }

--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/AccessTokenSourceFromDynamicConfiguration.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/AccessTokenSourceFromDynamicConfiguration.cs
@@ -42,5 +42,11 @@ namespace Corvus.Identity.ClientAuthentication.Azure.Internal
                         configuration,
                         this.tokenCredentialSource)));
         }
+
+        /// <inheritdoc/>
+        public void InvalidateFailedAccessToken(ClientIdentityConfiguration configuration)
+        {
+            this.tokenCredentialSource.InvalidateFailedAccessToken(configuration);
+        }
     }
 }

--- a/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/IMicrosoftRestTokenProviderSource.cs
+++ b/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/IMicrosoftRestTokenProviderSource.cs
@@ -36,5 +36,33 @@ namespace Corvus.Identity.ClientAuthentication.MicrosoftRest
         /// </para>
         /// </remarks>
         ITokenProvider GetTokenProvider(string[] scopes);
+
+        /// <summary>
+        /// Gets a new <see cref="ITokenProvider"/> to replace one that seems to have stopped
+        /// working.
+        /// </summary>
+        /// <param name="scopes">
+        /// The scopes for which the token is required.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ITokenProvider"/> to use from now on.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// Some sources of access tokens will become invalid under certain circumstances. For
+        /// example, when using ClientID/ClientSecret credentials to authenticate as a service
+        /// principle, the secret will expire at some point. With short key rotation cycles, this
+        /// can happen fairly frequently, but in any case it will always happen eventually.
+        /// </para>
+        /// <para>
+        /// This method enables the application to obtain updated credentials. It also enables the
+        /// <see cref="IAccessTokenSource"/> implementation to know that the credentials
+        /// in question are no longer valid. Implementations that cache credentials can choose to
+        /// stop handing out the now-failed cached credentials to any futher calls to
+        /// <see cref="GetTokenProvider"/>, making those wait until refreshed credentials have
+        /// become available.
+        /// </para>
+        /// </remarks>
+        ITokenProvider GetReplacementForFailedTokenProvider(string[] scopes);
     }
 }

--- a/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/IMicrosoftRestTokenProviderSourceFromDynamicConfiguration.cs
+++ b/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/IMicrosoftRestTokenProviderSourceFromDynamicConfiguration.cs
@@ -29,5 +29,17 @@ namespace Corvus.Identity.ClientAuthentication.MicrosoftRest
         ValueTask<IMicrosoftRestTokenProviderSource> TokenProviderSourceForConfigurationAsync(
             ClientIdentityConfiguration configuration,
             CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes any cached tokens for the specified identity. Called when an application has
+        /// reason to believe that credentials are out of date, and may need underlying secrets to
+        /// be reloaded.
+        /// </summary>
+        /// <param name="configuration">
+        /// The <see cref="ClientIdentityConfiguration"/> describing the identity for which cached
+        /// credentials no longer seem to be working..
+        /// </param>
+        void InvalidateFailedTokenProviderSource(
+            ClientIdentityConfiguration configuration);
     }
 }

--- a/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/Internal/MicrosoftRestTokenProviderSource.cs
+++ b/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/Internal/MicrosoftRestTokenProviderSource.cs
@@ -4,6 +4,8 @@
 
 namespace Corvus.Identity.ClientAuthentication.MicrosoftRest.Internal
 {
+    using System;
+
     using Microsoft.Rest;
 
     /// <summary>
@@ -12,6 +14,7 @@ namespace Corvus.Identity.ClientAuthentication.MicrosoftRest.Internal
     internal class MicrosoftRestTokenProviderSource : IMicrosoftRestTokenProviderSource
     {
         private readonly IAccessTokenSource tokenSource;
+        private readonly Action? invalidate;
 
         /// <summary>
         /// Creates a <see cref="MicrosoftRestTokenProviderSource"/>.
@@ -19,10 +22,27 @@ namespace Corvus.Identity.ClientAuthentication.MicrosoftRest.Internal
         /// <param name="serviceIdentityTokenSource">
         /// The source from which to obtain access tokens.
         /// </param>
+        /// <param name="invalidate">
+        /// Optional callback enabling this provider to invalidate any cached copy of the
+        /// credentials it relies on.
+        /// </param>
         public MicrosoftRestTokenProviderSource(
-            IAccessTokenSource serviceIdentityTokenSource)
+            IAccessTokenSource serviceIdentityTokenSource,
+            Action? invalidate)
         {
             this.tokenSource = serviceIdentityTokenSource;
+            this.invalidate = invalidate;
+        }
+
+        /// <inheritdoc/>
+        public ITokenProvider GetReplacementForFailedTokenProvider(string[] scopes)
+        {
+            if (this.invalidate is not null)
+            {
+                this.invalidate();
+            }
+
+            return this.GetTokenProvider(scopes);
         }
 
         /// <inheritdoc/>

--- a/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/Internal/MicrosoftRestTokenProviderSourceFromDynamicConfiguration.cs
+++ b/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/Internal/MicrosoftRestTokenProviderSourceFromDynamicConfiguration.cs
@@ -29,13 +29,21 @@ namespace Corvus.Identity.ClientAuthentication.MicrosoftRest.Internal
         }
 
         /// <inheritdoc/>
+        public void InvalidateFailedTokenProviderSource(ClientIdentityConfiguration configuration)
+        {
+            this.tokenSourceFromDynamicConfiguration.InvalidateFailedAccessToken(configuration);
+        }
+
+        /// <inheritdoc/>
         public async ValueTask<IMicrosoftRestTokenProviderSource> TokenProviderSourceForConfigurationAsync(
             ClientIdentityConfiguration configuration, CancellationToken cancellationToken)
         {
             IAccessTokenSource tokenSource = await this.tokenSourceFromDynamicConfiguration.AccessTokenSourceForConfigurationAsync(
                 configuration, cancellationToken)
                 .ConfigureAwait(false);
-            return new MicrosoftRestTokenProviderSource(tokenSource);
+            return new MicrosoftRestTokenProviderSource(
+                tokenSource,
+                () => this.InvalidateFailedTokenProviderSource(configuration));
         }
     }
 }

--- a/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/Internal/ServiceIdentityMicrosoftRestTokenProviderSource.cs
+++ b/Solutions/Corvus.Identity.MicrosoftRest/Corvus/Identity/ClientAuthentication/MicrosoftRest/Internal/ServiceIdentityMicrosoftRestTokenProviderSource.cs
@@ -21,7 +21,7 @@ namespace Corvus.Identity.ClientAuthentication.MicrosoftRest.Internal
         /// </param>
         public ServiceIdentityMicrosoftRestTokenProviderSource(
             IServiceIdentityAccessTokenSource underlyingSource)
-            : base(underlyingSource)
+            : base(underlyingSource, null)
         {
         }
     }

--- a/Solutions/Corvus.Identity.Specs/Corvus.Identity.Specs.csproj
+++ b/Solutions/Corvus.Identity.Specs/Corvus.Identity.Specs.csproj
@@ -40,6 +40,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <SpecFlowObsoleteCodeBehindFiles Remove="Corvus\Identity\Azure\TokenCredentialSourceFromDynamicConfiguration\AdAppWithSecretInKeyVault - Copy.feature.cs" />
+    <SpecFlowObsoleteCodeBehindFiles Remove="Corvus\Identity\Azure\TokenCredentialSourceFromDynamicConfiguration\ClientIdentityConfiguration - Copy.feature.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Endjin.RecommendedPractices" Version="1.3.0-PullRequest0026.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -55,6 +60,12 @@
     <ProjectReference Include="..\Corvus.Identity.MicrosoftRest\Corvus.Identity.MicrosoftRest.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="Corvus\Identity\Azure\TokenCredentialSourceFromDynamicConfiguration\CacheInvalidation.feature.cs">
+      <DependentUpon>CacheInvalidation.feature</DependentUpon>
+    </Compile>
+    <Compile Update="Corvus\Identity\Azure\TokenCredentialSourceFromDynamicConfiguration\SimpleSourceTypes.feature.cs">
+      <DependentUpon>SimpleSourceTypes.feature</DependentUpon>
+    </Compile>
     <Compile Update="Corvus\Identity\ManagedServiceIdentity\ClientAuthentication\ServiceIdentityMicrosoftRestTokenProvider.feature.cs">
       <DependentUpon>ServiceIdentityMicrosoftRestTokenProvider.feature</DependentUpon>
     </Compile>
@@ -65,6 +76,14 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <SpecFlowFeatureFiles Update="Corvus\Identity\Azure\TokenCredentialSourceFromDynamicConfiguration\CacheInvalidation.feature">
+      <Visible>$(UsingMicrosoftNETSdk)</Visible>
+      <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
+    </SpecFlowFeatureFiles>
+    <SpecFlowFeatureFiles Update="Corvus\Identity\Azure\TokenCredentialSourceFromDynamicConfiguration\SimpleSourceTypes.feature">
+      <Visible>$(UsingMicrosoftNETSdk)</Visible>
+      <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
+    </SpecFlowFeatureFiles>
     <SpecFlowFeatureFiles Update="Corvus\Identity\ManagedServiceIdentity\ClientAuthentication\ServiceIdentityMicrosoftRestTokenProvider.feature">
       <Visible>$(UsingMicrosoftNETSdk)</Visible>
       <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/AzureTokenCredentialAccessTokenSource.feature
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/AzureTokenCredentialAccessTokenSource.feature
@@ -75,13 +75,27 @@ Scenario: Token acquisition fails with AuthenticationFailedException
 # Sometimes applications find that a token that was once working no longer is. In situations where key
 # rotation is in use, this is normal, and applications can tell the token source that they want it to
 # try to reload the credentials behind the source.
-Scenario: Replace token
+Scenario: Replace token via IAccessTokenSource
     Given the AccessTokenRequest scope is 'https://management.core.windows.net/.default'
     And the AccessTokenRequest has additional claims of 'claim1 claim2'
     And IAccessTokenSource.GetAccessTokenAsync is called
     When IAccessTokenSource.GetReplacementForFailedAccessTokenAsync is called
     And the underlying TokenCredential returns a successful result
     Then the IAzureTokenCredentialSource should have been asked to replace the credential
+    And the scope should have been passed on to TokenCredential.GetTokenAsync
+    And the Claims should have been passed on to TokenCredential.GetTokenAsync
+    And the TenantId passed to TokenCredential.GetTokenAsync should be null
+    And the ParentRequestId passed to TokenCredential.GetTokenAsync should be null
+    And the AccessToken returned by IAccessTokenSource.GetAccessTokenAsync should be the same as was returned by TokenCredential.GetTokenAsync
+    And the ExpiresOn returned by IAccessTokenSource.GetAccessTokenAsync should be the same as was returned by TokenCredential.GetTokenAsync
+
+Scenario: Replace token via IAccessTokenSourceFromDynamicConfiguration
+    Given the AccessTokenRequest scope is 'https://management.core.windows.net/.default'
+    And the AccessTokenRequest has additional claims of 'claim1 claim2'
+    And IAccessTokenSource.GetAccessTokenAsync is called
+    When IAccessTokenSourceFromDynamicConfiguration.InvalidateFailedAccessToken is called
+    And the underlying TokenCredential returns a successful result
+    Then the IAzureTokenCredentialSourceFromDynamicConfiguration should have been asked to invalidate the credential
     And the scope should have been passed on to TokenCredential.GetTokenAsync
     And the Claims should have been passed on to TokenCredential.GetTokenAsync
     And the TenantId passed to TokenCredential.GetTokenAsync should be null

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/TokenCredentialSourceFromDynamicConfiguration/AdAppWithSecretInKeyVault.feature
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/TokenCredentialSourceFromDynamicConfiguration/AdAppWithSecretInKeyVault.feature
@@ -1,47 +1,7 @@
-﻿Feature: ClientIdentityConfiguration
+﻿Feature: TokenCredentialSourceFromDynamicConfiguration AD App with secret in Key Vault
     As the person responsible for deploying and configuring an application that uses services secured by Azure Active Directory
     I need to be able to supply the necessary details and credentials in various different ways
     So that I can obtain the correct credentials while meeting the security requirements of my application
-
-Scenario: Managed identity
-    Given configuration of
-        """
-        {
-            "ClientIdentity": { "IdentitySourceType": "Managed" }
-        }
-        """
-    When a TokenCredential is fetched for this configuration
-    Then the TokenCredential should be of type 'ManagedIdentityCredential'
-
-# TODO:
-# GetReplacementForFailedAccessTokenAsync for ManagedIdentity - not recoverable, so what do we do?
-
-Scenario: Default Azure Credential
-    Given configuration of
-        """
-        {
-          "ClientIdentity": { "IdentitySourceType": "AzureIdentityDefaultAzureCredential" }
-        }
-        """
-    When a TokenCredential is fetched for this configuration
-    Then the TokenCredential should be of type 'DefaultAzureCredential'
-
-Scenario: Service principle client ID and secret in configuration
-    Given configuration of
-        """
-        {
-          "ClientIdentity": {
-            "AzureAdAppTenantId": "b39db674-9ba1-4343-8d4e-004675b5d7a8",
-            "AzureAdAppClientId": "831c7dcb-516a-4e6b-9b74-347264c67397",
-            "AzureAdAppClientSecretPlainText": "s3cret!"
-          }
-        }
-        """
-    When a TokenCredential is fetched for this configuration
-    Then the TokenCredential should be of type 'ClientSecretCredential'
-	And the ClientSecretCredential tenantId should be 'b39db674-9ba1-4343-8d4e-004675b5d7a8'
-	And the ClientSecretCredential appId should be '831c7dcb-516a-4e6b-9b74-347264c67397'
-	And the ClientSecretCredential clientSecret should be 's3cret!'
 
 Scenario: Service principle client ID in configuration and secret in key vault via service identity
     Given configuration of

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/TokenCredentialSourceFromDynamicConfiguration/CacheInvalidation.feature
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/TokenCredentialSourceFromDynamicConfiguration/CacheInvalidation.feature
@@ -1,0 +1,65 @@
+﻿Feature: TokenCredentialSourceFromDynamicConfiguration Cache Invalidation
+    As a developer using client identities obtained from ClientIdentityConfiguration instances
+    I need to be able to remove bad credentials from the cache
+    So that I can pick up updated credentials in key rotation scenarios
+
+Scenario Outline: Service principle client ID in configuration and secret in key vault via service identity
+    Given configuration of
+        """
+        {
+          "ClientIdentity": {
+            "AzureAdAppTenantId": "b39db674-9ba1-4343-8d4e-004675b5d7a8",
+            "AzureAdAppClientId": "831c7dcb-516a-4e6b-9b74-347264c67397",
+            "AzureAdAppClientSecretInKeyVault": {
+              "VaultName": "myvault",
+              "SecretName": "MyAzureAdAppClientSecret" 
+            }
+          }
+        }
+        """
+    And the secret cache returns 's3cret!' for the secret named 'MyAzureAdAppClientSecret' in 'myvault'
+    When this ClientIdentityConfiguration is invalidated via '<InvalidationMechanism>'
+    Then the secret cache should have seen these credentials invalidated
+    | VaultName | SecretName               | Credential                       |
+    | myvault   | MyAzureAdAppClientSecret | AzureAdAppClientSecretInKeyVault |
+
+    Examples:
+    | InvalidationMechanism                               |
+    | IAzureTokenCredentialSource                         |
+    | IAzureTokenCredentialSourceFromDynamicConfiguration |
+
+Scenario Outline: Service principle client ID in configuration and secret in key vault via different service identity with client ID in config and secret in key vault via service identity
+    Given configuration of
+        """
+        {
+          "ClientIdentity": {
+            "AzureAdAppTenantId": "d0e416b5-1b5d-431e-9448-94a70453889f",
+            "AzureAdAppClientId": "2c5cb5ea-e304-40cf-bdca-81a0d8cf3968",
+            "AzureAdAppClientSecretInKeyVault": {
+              "VaultName": "customervault",
+              "SecretName": "CustomerAzureAdAppClientSecret",
+              "VaultClientIdentity": {
+                "AzureAdAppTenantId": "b39db674-9ba1-4343-8d4e-004675b5d7a8",
+                "AzureAdAppClientId": "831c7dcb-516a-4e6b-9b74-347264c67397",
+                "AzureAdAppClientSecretInKeyVault": {
+                  "VaultName": "myvault",
+                  "SecretName": "ClientSecretForAzureAdAppWithWhichWeAccessClientKeyVault",
+                  "VaultClientIdentity": { "IdentitySourceType": "Managed" }
+                }
+              }
+            }
+          }
+        }
+        """
+    And the key vault 'customervault' returns 'targetsecret!' for the secret named 'CustomerAzureAdAppClientSecret'
+    And the key vault 'myvault' returns 'vaultSpSecret' for the secret named 'ClientSecretForAzureAdAppWithWhichWeAccessClientKeyVault'
+    When this ClientIdentityConfiguration is invalidated via '<InvalidationMechanism>'
+    Then the secret cache should have seen these credentials invalidated
+    | VaultName | SecretName               | Credential                       |
+    | customervault | CustomerAzureAdAppClientSecret                           | AzureAdAppClientSecretInKeyVault                                  |
+    | myvault       | ClientSecretForAzureAdAppWithWhichWeAccessClientKeyVault | AzureAdAppClientSecretInKeyVault.AzureAdAppClientSecretInKeyVault |
+
+    Examples:
+    | InvalidationMechanism                               |
+    | IAzureTokenCredentialSource                         |
+    | IAzureTokenCredentialSourceFromDynamicConfiguration |

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/TokenCredentialSourceFromDynamicConfiguration/SimpleSourceTypes.feature
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/TokenCredentialSourceFromDynamicConfiguration/SimpleSourceTypes.feature
@@ -1,0 +1,44 @@
+﻿Feature: TokenCredentialSourceFromDynamicConfiguration with simple ClientIdentityConfiguration
+    As the person responsible for deploying and configuring an application that uses services secured by Azure Active Directory
+    I need to be able to supply the necessary details and credentials in various different ways
+    So that I can obtain the correct credentials while meeting the security requirements of my application
+
+Scenario: Managed identity
+    Given configuration of
+        """
+        {
+            "ClientIdentity": { "IdentitySourceType": "Managed" }
+        }
+        """
+    When a TokenCredential is fetched for this configuration
+    Then the TokenCredential should be of type 'ManagedIdentityCredential'
+
+# TODO:
+# GetReplacementForFailedAccessTokenAsync for ManagedIdentity - not recoverable, so what do we do?
+
+Scenario: Default Azure Credential
+    Given configuration of
+        """
+        {
+          "ClientIdentity": { "IdentitySourceType": "AzureIdentityDefaultAzureCredential" }
+        }
+        """
+    When a TokenCredential is fetched for this configuration
+    Then the TokenCredential should be of type 'DefaultAzureCredential'
+
+Scenario: Service principle client ID and secret in configuration
+    Given configuration of
+        """
+        {
+          "ClientIdentity": {
+            "AzureAdAppTenantId": "b39db674-9ba1-4343-8d4e-004675b5d7a8",
+            "AzureAdAppClientId": "831c7dcb-516a-4e6b-9b74-347264c67397",
+            "AzureAdAppClientSecretPlainText": "s3cret!"
+          }
+        }
+        """
+    When a TokenCredential is fetched for this configuration
+    Then the TokenCredential should be of type 'ClientSecretCredential'
+	And the ClientSecretCredential tenantId should be 'b39db674-9ba1-4343-8d4e-004675b5d7a8'
+	And the ClientSecretCredential appId should be '831c7dcb-516a-4e6b-9b74-347264c67397'
+	And the ClientSecretCredential clientSecret should be 's3cret!'


### PR DESCRIPTION
This enables invalidation of cached credential data without needing to hold onto the individual token source objects: you can now just pass a `ClientIdentityConfiguration` if that is more convenient.