### PR TITLE
Enable Azure CLI, VS, and VS Code credentials

### DIFF
--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/ClientIdentitySourceTypes.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/ClientIdentitySourceTypes.cs
@@ -50,5 +50,11 @@ namespace Corvus.Identity.ClientAuthentication.Azure
         /// suitable for local development purposes.
         /// </summary>
         AzureIdentityDefaultAzureCredential,
+
+        /// <summary>
+        /// Visual Studio Code's authentication should be used to determine the identity. (For local
+        /// development purposes only.)
+        /// </summary>
+        VisualStudioCode,
     }
 }

--- a/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/AzureTokenCredentialSourceFromConfiguration.cs
+++ b/Solutions/Corvus.Identity.Azure/Corvus/Identity/ClientAuthentication/Azure/Internal/AzureTokenCredentialSourceFromConfiguration.cs
@@ -63,9 +63,12 @@ namespace Corvus.Identity.ClientAuthentication.Azure.Internal
             {
                 ClientIdentitySourceTypes.Managed => new ManagedIdentityCredential(),
                 ClientIdentitySourceTypes.AzureIdentityDefaultAzureCredential => new DefaultAzureCredential(),
+                ClientIdentitySourceTypes.AzureCli => new AzureCliCredential(),
+                ClientIdentitySourceTypes.VisualStudio => new VisualStudioCredential(),
+                ClientIdentitySourceTypes.VisualStudioCode => new VisualStudioCodeCredential(),
 
                 _ => throw new ArgumentException(
-                    $"Unsupported IdentitySourceType: ${identitySourceType}",
+                    $"Unsupported IdentitySourceType: {identitySourceType}",
                     nameof(configuration)),
             };
             return new AzureTokenCredentialSource(tokenCredential, null);

--- a/Solutions/Corvus.Identity.Examples.AzureFunctions/packages.lock.json
+++ b/Solutions/Corvus.Identity.Examples.AzureFunctions/packages.lock.json
@@ -67,8 +67,8 @@
       },
       "Azure.Identity": {
         "type": "Transitive",
-        "resolved": "1.8.0",
-        "contentHash": "xnsY/lgAG4bO5d2akXc1hqfvknIk+u3gh5Ma33KN2uyNeU3C5AzIfrwO/N/b9D/7dk4MyXai4JGKHNgHjcoFsA==",
+        "resolved": "1.8.1",
+        "contentHash": "pxpGgVW6SCG+RewCVVlsEtcnQsLmlRobVlknY1Ir6t00iu2eRbdH/+ignhDnTaKlNN8pHfMJH5rTkJs9W4rQOg==",
         "dependencies": {
           "Azure.Core": "1.25.0",
           "Microsoft.Identity.Client": "4.46.0",
@@ -1740,7 +1740,7 @@
       "corvus.identity.azure": {
         "type": "Project",
         "dependencies": {
-          "Azure.Identity": "[1.8.0, )",
+          "Azure.Identity": "[1.8.1, )",
           "Azure.Security.KeyVault.Secrets": "[4.4.0, )",
           "Corvus.Identity.Abstractions": "[1.0.0, )",
           "Microsoft.Extensions.Caching.Memory": "[6.0.1, )",

--- a/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/TokenCredentialSourceFromDynamicConfiguration/SimpleSourceTypes.feature
+++ b/Solutions/Corvus.Identity.Specs/Corvus/Identity/Azure/TokenCredentialSourceFromDynamicConfiguration/SimpleSourceTypes.feature
@@ -42,3 +42,33 @@ Scenario: Service principle client ID and secret in configuration
 	And the ClientSecretCredential tenantId should be 'b39db674-9ba1-4343-8d4e-004675b5d7a8'
 	And the ClientSecretCredential appId should be '831c7dcb-516a-4e6b-9b74-347264c67397'
 	And the ClientSecretCredential clientSecret should be 's3cret!'
+
+Scenario: Azure CLI Credential
+    Given configuration of
+        """
+        {
+          "ClientIdentity": { "IdentitySourceType": "AzureCli" }
+        }
+        """
+    When a TokenCredential is fetched for this configuration
+    Then the TokenCredential should be of type 'AzureCliCredential'
+
+Scenario: Visual Studio Credential
+    Given configuration of
+        """
+        {
+          "ClientIdentity": { "IdentitySourceType": "VisualStudio" }
+        }
+        """
+    When a TokenCredential is fetched for this configuration
+    Then the TokenCredential should be of type 'VisualStudioCredential'
+
+Scenario: Visual Studio Code Credential
+    Given configuration of
+        """
+        {
+          "ClientIdentity": { "IdentitySourceType": "VisualStudioCode" }
+        }
+        """
+    When a TokenCredential is fetched for this configuration
+    Then the TokenCredential should be of type 'VisualStudioCodeCredential'

--- a/Solutions/Corvus.Identity.Specs/packages.lock.json
+++ b/Solutions/Corvus.Identity.Specs/packages.lock.json
@@ -97,8 +97,8 @@
       },
       "Azure.Identity": {
         "type": "Transitive",
-        "resolved": "1.8.0",
-        "contentHash": "xnsY/lgAG4bO5d2akXc1hqfvknIk+u3gh5Ma33KN2uyNeU3C5AzIfrwO/N/b9D/7dk4MyXai4JGKHNgHjcoFsA==",
+        "resolved": "1.8.1",
+        "contentHash": "pxpGgVW6SCG+RewCVVlsEtcnQsLmlRobVlknY1Ir6t00iu2eRbdH/+ignhDnTaKlNN8pHfMJH5rTkJs9W4rQOg==",
         "dependencies": {
           "Azure.Core": "1.25.0",
           "Microsoft.Identity.Client": "4.46.0",
@@ -1580,7 +1580,7 @@
       "corvus.identity.azure": {
         "type": "Project",
         "dependencies": {
-          "Azure.Identity": "[1.8.0, )",
+          "Azure.Identity": "[1.8.1, )",
           "Azure.Security.KeyVault.Secrets": "[4.4.0, )",
           "Corvus.Identity.Abstractions": "[1.0.0, )",
           "Microsoft.Extensions.Caching.Memory": "[6.0.1, )",


### PR DESCRIPTION
Resolves #273

We used to have to use `AzureIdentityDefaultAzureCredential` to take advantage of either Azure CLI or VS credentials, which was unnecessarily slow, because it would always first try to acquire a managed identity, only trying alternatives after timing out.

Also, we had no support for VS code before. (Although the VS Code Azure Account extension appears to have changed how it works in ways `Azure.Identity` has not yet caught up with - you need to be on an old version of the extension if you want this to work right now. This isn't something we can control - the exact same issue exists on Python because the basic problem is in the VS Code extension.)

This now enables the use of `AzureCli`, `VisualStudio`, or `VisualStudioCode` as an `IdentitySourceType`.